### PR TITLE
Add Åstorps kommun color scheme

### DIFF
--- a/source/sass/themes/astorp.scss
+++ b/source/sass/themes/astorp.scss
@@ -1,0 +1,21 @@
+$palette-1: #c6296e;
+$palette-1-safe: #c6296e;
+$palette-1-text: #000;
+
+$palette-2: #712082;
+$palette-2-safe: #712082;
+$palette-2-text: #fff;
+
+$palette-3: #a54e82;
+$palette-3-safe: #a54e82;
+$palette-3-text: #fff;
+
+$palette-4: #660033;
+$palette-4-safe: #660033;
+$palette-4-text: #fff;
+
+$palette-5: #a61380;
+$palette-5-safe: #a61380;
+$palette-5-text: #fff;
+
+@import '../bootstrap';


### PR DESCRIPTION
Here is a work-in-progress color scheme for Åstorp kommun.

Let's see if this is the best workflow for this. I need this out in a hosted version that I can use with the latest Intranet platform, which should mean http://helsingborg-stad.github.io/styleguide-web/dist/css/hbg-prime-astorp.min.css.

I did not build on purpose since I was unsure what exactly was related to this change in the built files.

Could you please build and publish this new color scheme?