### PR TITLE
Change composer type to library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "helsingborg-stad/hwstyleguide-web",
-    "type": "styleguide",
+    "type": "library",
     "authors": [
         {
             "name": "Kristoffer Svanmark",


### PR DESCRIPTION
Changes the composer type from `styleguide` to `library`.

This makes it easier to use with plugins such as [composer-custom-directory-installer](https://github.com/mnsami/composer-custom-directory-installer).